### PR TITLE
Added _required render_field override

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ can be set in the form class or as an argument like above.
 
 * `_no_label`: Do not show label
 * `_no_required`: Do not show required asterisk
+* `_required`: Do show required asterisk (assumes `_no_required` is absent)
 * `_no_errors`: Do not show inline errors
 * `_inline`: Adds inline class to field
 * `_field_class`: Allows for custom field classes

--- a/semanticuiforms/templatetags/semanticui.py
+++ b/semanticuiforms/templatetags/semanticui.py
@@ -108,6 +108,8 @@ class Field():
 		# Required class
 		if self.field.field.required and not self.attrs.get("_no_required"):
 			self.values["class"].append("required")
+		elif self.attrs.get("_required") and not self.field.field.required:
+			self.values["class"].append("required")
 
 
 	def render(self):


### PR DESCRIPTION
Add option to `render_field` to override required in field definition.